### PR TITLE
Disable SwiftLint error

### DIFF
--- a/iOSEngineerCodeCheckTests/iOSEngineerCodeCheckTests.swift
+++ b/iOSEngineerCodeCheckTests/iOSEngineerCodeCheckTests.swift
@@ -9,7 +9,9 @@
 import XCTest
 @testable import iOSEngineerCodeCheck
 
+// swiftlint:disable:next type_name
 class iOSEngineerCodeCheckTests: XCTestCase {
+// swiftlint:disable:previous type_name
 
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.

--- a/iOSEngineerCodeCheckUITests/iOSEngineerCodeCheckUITests.swift
+++ b/iOSEngineerCodeCheckUITests/iOSEngineerCodeCheckUITests.swift
@@ -8,7 +8,9 @@
 
 import XCTest
 
+// swiftlint:disable:next type_name
 class iOSEngineerCodeCheckUITests: XCTestCase {
+// swiftlint:disable:previous type_name
 
     override func setUpWithError() throws {
         // Put setup code here. This method is called before the invocation of each test method in the class.


### PR DESCRIPTION
プロジェクト名が「iOS」と小文字で始まりテストのクラス名が小文字ではじまってるのでエラーが出てしまうので無効化。