### PR TITLE
README を読み込むように変更

### DIFF
--- a/iOSEngineerCodeCheck/ViewController/RepositoryDetailViewController/RepositoryDetailCollectionDataSource.swift
+++ b/iOSEngineerCodeCheck/ViewController/RepositoryDetailViewController/RepositoryDetailCollectionDataSource.swift
@@ -41,7 +41,7 @@ final class RepositoryDetailCollectionDataSource {
             }
 
             cell.repositoryInfoView.repository = item.repository
-//            cell.readmePublisher = GitHubReadmePublisher.readmePublisher(for: item.repository)
+            cell.readmePublisher = GitHubReadmePublisher.readmePublisher(for: item.repository)
             cell.delegate = self?.repositoryDetailCellDelegate
 
             return cell


### PR DESCRIPTION
GitHub API の rate limit で 403 が返って来ていたので一時的に README を読み込まない様にしていたのを戻した。